### PR TITLE
ALL permission above separate permissions

### DIFF
--- a/src/PermissionsBasedAuthTrait.php
+++ b/src/PermissionsBasedAuthTrait.php
@@ -180,12 +180,12 @@ trait PermissionsBasedAuthTrait
 
 	public static function hasPermissionsTo(Request $request, $ability)
 	{
-		if (isset(static::$permissionsForAbilities[$ability])) {
-			return $request->user()->can(static::$permissionsForAbilities[$ability]);
-		}
-
 		if (isset(static::$permissionsForAbilities['all'])) {
 			return $request->user()->can(static::$permissionsForAbilities['all']);
+		}
+
+		if (isset(static::$permissionsForAbilities[$ability])) {
+			return $request->user()->can(static::$permissionsForAbilities[$ability]);
 		}
 
 		return false;


### PR DESCRIPTION
``all`` permission overrides specifics permissions, like ``view``, ``update``, etc.