### PR TITLE
Update to use Spatie Permission 3.0.0 which uses L6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1.0",
-        "spatie/laravel-permission": "^2.16"
+        "spatie/laravel-permission": "^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Update composer to use spatie/laravel-permission 3.0.0 with Laravel 6 upgrade